### PR TITLE
fix mapstructure unit test error

### DIFF
--- a/client/websocket.go
+++ b/client/websocket.go
@@ -84,7 +84,7 @@ func (p *Client) Websocket(query string, options ...Option) *Subscription {
 
 			if respDataRaw["errors"] != nil {
 				var errs []*gqlerror.Error
-				if err = unpack(respDataRaw["errors"], errs); err != nil {
+				if err = unpack(respDataRaw["errors"], &errs); err != nil {
 					return err
 				}
 				if len(errs) > 0 {


### PR DESCRIPTION
fix unit test error "mapstructure: result must be a pointer". It appears instead of resolver returned error.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
